### PR TITLE
ユーザー登録機能の実装（住所・カード以外）

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :first_name, :last_name, :first_name__kana, :last_name__kana, :birth_year, :birth_month, :birth_day, :phone_num])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birth_year, :birth_month, :birth_day, :phone_num])
   end
   
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :first_name, :last_name, :first_name__kana, :last_name__kana, :birth_year, :birth_month, :birth_day, :phone_num])
   end
   
   private

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -65,14 +65,14 @@ class Users::RegistrationsController < Devise::RegistrationsController
   protected
 
   # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
-  def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  end
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
 
   # The path used after sign up.
   # def after_sign_up_path_for(resource)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -22,6 +22,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def sms_authentication_create
     session["devise.regist_data"]["user"]["phone_num"] = params[:user][:phone_num]
     @user = User.new(session["devise.regist_data"]["user"])
+    unless session["devise.regist_data"]["user"]["phone_num"].present?
+      flash.now[:alert] = @user.errors.full_messages
+      render :sms_authentication and return
+    end
     @user.save
     sign_in(:user, @user)
     redirect_to addresses_path

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,8 +1,32 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
+  before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
+
+  def registration
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(sign_up_params)
+    unless @user.valid?
+      flash.now[:alert] = @user.errors.full_messages
+      render :registration and return
+    end
+    session["devise.regist_data"] = {user: @user.attributes}
+    session["devise.regist_data"][:user]["password"] = params[:user][:password]
+    render :sms_authentication
+  end
+
+  def sms_authentication_create
+    session["devise.regist_data"]["user"]["phone_num"] = params[:user][:phone_num]
+    @user = User.new(session["devise.regist_data"]["user"])
+    @user.save
+    sign_in(:user, @user)
+    redirect_to addresses_path
+  end
+
 
   # GET /resource/sign_up
   # def new
@@ -38,7 +62,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params
@@ -46,9 +70,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # If you have extra params to permit, append them to the sanitizer.
-  # def configure_account_update_params
-  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  # end
+  def configure_account_update_params
+    devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  end
 
   # The path used after sign up.
   # def after_sign_up_path_for(resource)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  validates :nickname, :firstname, :lastname, :first_name_kana, :last_name_kana, :birth_year, :birth_month, :birth_day, :phone_num ,presence: true, on: :sms_authentication_create
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,5 +3,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  validates :nickname, :firstname, :lastname, :first_name_kana, :last_name_kana, :birth_year, :birth_month, :birth_day, :phone_num ,presence: true, on: :sms_authentication_create
+  validates :nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birth_year, :birth_month, :birth_day, :phone_num ,presence: true, on: :sms_authentication_create
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,5 +3,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  validates :nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birth_year, :birth_month, :birth_day, :phone_num ,presence: true, on: :sms_authentication_create
+  validates :nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birth_year, :birth_month, :birth_day, presence: true
 end

--- a/app/views/devise/registrations/registration.html.haml
+++ b/app/views/devise/registrations/registration.html.haml
@@ -4,7 +4,7 @@
     .signup-main__container
       .signup-main__container__top
         会員情報入力
-      = form_with model: @user, url: "#", method: 'get', local: true, class: "signup-form" do |f|
+      = form_with model: @user, url: signups_registration_path, local: true, class: "signup-form" do |f|
         .signup-main__container__box
           .signup-main__container__form-group
             = f.label 'ニックネーム'

--- a/app/views/devise/registrations/sms_authentication.html.haml
+++ b/app/views/devise/registrations/sms_authentication.html.haml
@@ -4,7 +4,7 @@
     .signup-main__container
       .signup-main__container__top
         電話番号認証
-      = form_with model: @user, url: "#", method: 'post', local: true, class: "signup-form" do |f|
+      = form_with model: @user, url: signups_sms_authentication_path, local: true, class: "signup-form" do |f|
         .signup-main__container__box
           .signup-main__container__form-group
             = f.label '携帯電話の番号'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   }
   devise_scope :user do
     get 'signups/registration', to: 'users/registrations#registration'
+    post 'signups/registration', to: 'users/registrations#create'
     get 'signups/sms_authentication', to: 'users/registrations#sms_authentication'
+    post 'signups/sms_authentication', to: 'users/registrations#sms_authentication_create'
   end
 
   root 'products#index'


### PR DESCRIPTION
# what
ユーザーの新規登録機能のみ実装。
nickname, first_name, last_name, first_name_kana, last_name_kana, birth_year, birth_month, birth_day, phone_numを登録できるようにする。
バリデーションは簡易的なものにとどめ、エラー文を表示する機能はまだ実装しない。

# why
細かい実装は後にして、まずはユーザーの登録をできるようにするため。