### PR TITLE
database.yamlを変更

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -14,8 +14,8 @@ default: &default
   encoding: utf8
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
-  password:
-  socket: /tmp/mysql.sock
+  password: <%= ENV['DATABASE_PASSWORD'] %>
+  socket: /var/lib/mysql/mysql.sock
 
 development:
   <<: *default


### PR DESCRIPTION
# What
dayabase.yamlのパスワードとソケットの変更

# Why
環境変数を使う事でAWS上でMySQLを使えるようにするため